### PR TITLE
Use Homebrew only to install rig

### DIFF
--- a/mac-homebrew.md
+++ b/mac-homebrew.md
@@ -14,15 +14,41 @@ brew --version
 インストールされていない場合は [公式サイト](https://brew.sh/) の手順で導入してください。
 
 ## 3. インストール手順
-1. R をインストール
+1. rig を Homebrew でインストール
    ```bash
-   brew install --cask r
+   brew tap r-lib/rig
+   brew install rig
    ```
-2. RStudio をインストール
+2. rig で R をインストール
+   1. rig のバージョンを確認
+      ```bash
+      rig --version
+      ```
+   2. 利用可能な R を確認
+      ```bash
+      rig available
+      ```
+   3. 最新版をインストール
+      ```bash
+      rig add release
+      ```
+      バージョンを指定する場合:
+      ```bash
+      rig add 4.4.3
+      ```
+   4. インストール済みバージョンを確認
+      ```bash
+      rig list
+      ```
+   5. 使用するバージョンを指定
+      ```bash
+      rig default 4.4.3
+      ```
+3. RStudio をインストール
    ```bash
    brew install --cask rstudio
    ```
-3. RStudio を起動しパッケージをインストール
+4. RStudio を起動しパッケージをインストール
    ```r
    install.packages("pacman")
    pacman::p_load(skimr, comorbidity, broom, tidyverse, here, openxlsx, tableone)


### PR DESCRIPTION
## Summary
- Expand macOS Homebrew guide with step-by-step rig instructions

## Testing
- `npm install -g markdownlint-cli@0.39.0` *(fails: 403 Forbidden)*
- `markdownlint mac-homebrew.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ef25a88e88326ab527a07899ffc75