### PR TITLE
Add RStudio post-install setup guide

### DIFF
--- a/mac-homebrew.md
+++ b/mac-homebrew.md
@@ -136,17 +136,7 @@ brew install --cask xquartz
 brew install --cask rstudio
 ```
 
-## 7. RStudio で必要なパッケージを入れる
+## 7. RStudio の初期設定とパッケージのインストール
 
-1. 「アプリケーション」フォルダから RStudio を開きます。
-2. 画面下部の「Console」と書かれた白い場所に次の2行を順番に貼り付け、Enter を押します。
-
-```r
-install.packages("pacman")
-pacman::p_load(skimr, comorbidity, broom, tidyverse, here, openxlsx, tableone)
-```
-
-ここでは `pacman::p_load` を使っていますが、`pak` パッケージを入れて `pak::pak()` でインストールしても構いません。
-
-これで授業で使う R の準備は完了です。
+RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。
 

--- a/mac-rig.md
+++ b/mac-rig.md
@@ -109,16 +109,6 @@ uname -m
 1. `Download RStudio for Mac` をクリックし、`RStudio.dmg` をダウンロードします。
 2. ダウンロードした `.dmg` ファイルをダブルクリックし、表示されるウインドウから **RStudio** を **アプリケーション** フォルダにドラッグします。
 
-## 6. RStudio で必要なパッケージを入れる
+## 6. RStudio の初期設定とパッケージのインストール
 
-1. 「アプリケーション」フォルダから RStudio を開きます。
-2. 画面下部の「Console」と書かれた白い場所に次の2行を順番に貼り付け、Enter を押します。
-
-```r
-install.packages("pacman")
-pacman::p_load(skimr, comorbidity, broom, tidyverse, here, openxlsx, tableone)
-```
-
-ここでは `pacman::p_load` を使っていますが、`pak` パッケージを入れて `pak::pak()` でインストールしても構いません。
-
-これで授業で使う R の準備は完了です。
+RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。

--- a/mac-rstudio.md
+++ b/mac-rstudio.md
@@ -72,14 +72,6 @@ uname -m
 <img width="496" height="327" alt="image" src="https://github.com/user-attachments/assets/1071ae0c-391e-4241-9954-b3bd31f2c2e2" style="border: 1px solid #000;" />
 
 
-## 4. RStudio で必要なパッケージを入れる
+## 4. RStudio の初期設定とパッケージのインストール
 
-1. 「アプリケーション」フォルダから RStudio を開きます。
-2. 画面下部の「Console」と書かれた白い場所に次の2行を順番に貼り付け、Enter を押します。
-
-```r
-install.packages("pacman")
-pacman::p_load(skimr, comorbidity, broom, tidyverse, here, openxlsx, tableone)
-```
-
-これで授業で使う R の準備は完了です。
+RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。

--- a/rstudio-post-install.md
+++ b/rstudio-post-install.md
@@ -1,0 +1,35 @@
+# RStudioインストール後の準備
+
+## 1. 文字コードを UTF-8 に設定する
+1. RStudio を起動します。
+2. メニューの **Tools › Global Options** を開き、左の **Code** › **Saving** を選びます。
+3. "Default text encoding" が "UTF-8" になっていることを確認します。
+   <!-- 画像: Global Options の Code > Saving で UTF-8 を確認している画面 -->
+4. もし別の文字コードになっている場合は "Change..." から "UTF-8" を選択し、"Apply" を押します。
+
+## 2. ペインのレイアウトを変更する
+1. **Tools › Global Options** の **Pane Layout** を開きます。
+2. "Console" を右上にドラッグします。
+   <!-- 画像: Pane Layout で Console を右上に移動している様子 -->
+3. 右下のペインに "Environment" を追加します。
+   <!-- 画像: Pane Layout で右下に Environment を追加している様子 -->
+
+## 3. プロジェクトを作成する
+1. 右上の "Project: (None)" をクリックし、**New Project...** を選びます。
+2. **New Directory** › **New Project** を選択します。
+3. フォルダ名に `JSNPT_RSeminar` と入力し、保存場所は **ドキュメント** もしくは **デスクトップ** など任意の場所を選びます。
+   <!-- 画像: New Project で JSNPT_RSeminar を作成するダイアログ -->
+4. そのまま **Create Project** を押します。`renv` の設定は変更不要です。
+   <!-- 画像: 作成されたプロジェクトの画面 -->
+
+## 4. 必要なパッケージをインストールする
+1. Console に次の 2 行を貼り付け、Enter を押します。
+
+```r
+install.packages("pacman")
+pacman::p_load(skimr, comorbidity, broom, tidyverse, here, openxlsx, tableone)
+```
+
+ここでは `pacman::p_load` を使っていますが、`pak` パッケージを入れて `pak::pak()` でインストールしても構いません。
+
+これで授業で使う R の準備は完了です。

--- a/windows-rig.md
+++ b/windows-rig.md
@@ -104,16 +104,6 @@ winget install -e Posit.RStudio
 
 `-e` は完全一致検索のオプションです。
 
-## 9. RStudio で必要なパッケージを入れる
+## 9. RStudio の初期設定とパッケージのインストール
 
-1. スタートメニューから RStudio を開きます。
-2. 画面下部の「Console」と書かれた白い場所に次の2行を順番に貼り付け、Enter を押します。
-
-```r
-install.packages("pacman")
-pacman::p_load(skimr, comorbidity, broom, tidyverse, here, openxlsx, tableone)
-```
-
-ここでは `pacman::p_load` を使っていますが、`pak` パッケージを入れて `pak::pak()` でインストールしても構いません。
-
-これで授業で使う R の準備は完了です。
+RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。

--- a/windows-rstudio.md
+++ b/windows-rstudio.md
@@ -63,14 +63,6 @@ mkdir C:\Users\$Env:USERNAME\Documents\R\libs
 6. 再度 RStudio のダウンロードページに戻り、**RStudio** の Windows 版をダウンロードしてインストールします。
    - こちらも基本的に「Next」を押し続け、最後に「Finish」で閉じれば大丈夫です。
 
-## 5. パッケージのインストール
+## 5. RStudio の初期設定とパッケージのインストール
 
-1. スタートメニューから RStudio を開きます。
-2. 画面下部の「Console」と書かれた白い場所に次の2行を順番に貼り付け、Enter を押します。
-
-```r
-install.packages("pacman")
-pacman::p_load(skimr, comorbidity, broom, tidyverse, here, openxlsx, tableone)
-```
-
-これで授業で使う R の準備は完了です。
+RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。

--- a/windows-winget.md
+++ b/windows-winget.md
@@ -64,14 +64,6 @@ winget install -e Posit.RStudio
 
 これで RStudio もインストールされます。
 
-## 5. RStudio で必要なパッケージを入れる
+## 5. RStudio の初期設定とパッケージのインストール
 
-1. スタートメニューから RStudio を開きます。
-2. 画面下部の「Console」と書かれた白い場所に次の2行を順番に貼り付け、Enter を押します。
-
-```r
-install.packages("pacman")
-pacman::p_load(skimr, comorbidity, broom, tidyverse, here, openxlsx, tableone)
-```
-
-これで授業で使う R の準備は完了です。
+RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。


### PR DESCRIPTION
## Summary
- add `rstudio-post-install.md` with UTF-8 check, pane layout, project creation, and required packages
- point platform-specific install guides to the new post-install guide instead of embedding `pacman` instructions

## Testing
- `markdownlint mac-homebrew.md mac-rstudio.md mac-rig.md windows-rstudio.md windows-rig.md windows-winget.md rstudio-post-install.md` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a02b33549c832686983f5751b2d469