### PR TITLE
Cross-link Windows path issue guidance

### DIFF
--- a/windows-rig.md
+++ b/windows-rig.md
@@ -1,7 +1,7 @@
 # Windows: rig で複数バージョンを管理
 
 > [!NOTE]
-> RStudio は Windows 10 以降のみサポートされています。Windows 7/8 を利用している場合は、OS を Windows 10 以上にアップグレードすることをおすすめします。旧OSでのインストールは過去バージョンを自己責任で導入してください。
+> RStudio は Windows 10 以降のみサポートされています。Windows 7/8 を利用している場合は、OS を Windows 10 以上にアップグレードすることをおすすめします。旧OSでのインストールは過去バージョンを自己責任で導入してください。 詳細はこちら: [Windows7/8に関する注意点](windows-r-japanese-path-issues.md)。
 
 PowerShell の開き方やコマンドの貼り付け方から丁寧に説明します。
 

--- a/windows-rstudio.md
+++ b/windows-rstudio.md
@@ -3,7 +3,7 @@
 RStudio のサイトから R・Rtools・RStudio を順番に入れる、もっとも一般的な方法です。迷ったらまずはこの手順で大丈夫です。PowerShell の開き方やコマンドの貼り付け方から丁寧に説明します。
 
 > [!NOTE]
-> RStudio は Windows 10 以降のみサポートされています。Windows 7/8 を利用している場合は、OS を Windows 10 以上にアップグレードすることをおすすめします。旧OSでのインストールは過去バージョンを自己責任で導入してください。
+> RStudio は Windows 10 以降のみサポートされています。Windows 7/8 を利用している場合は、OS を Windows 10 以上にアップグレードすることをおすすめします。旧OSでのインストールは過去バージョンを自己責任で導入してください。 詳細はこちら: [Windows7/8に関する注意点](windows-r-japanese-path-issues.md)。
 
 ## 0. PowerShell を管理者として開く
 

--- a/windows-winget.md
+++ b/windows-winget.md
@@ -1,7 +1,7 @@
 # Windows: winget での簡単インストール
 
 > [!NOTE]
-> RStudio は Windows 10 以降のみサポートされています。Windows 7/8 を利用している場合は、OS を Windows 10 以上にアップグレードすることをおすすめします。旧OSでのインストールは過去バージョンを自己責任で導入してください。
+> RStudio は Windows 10 以降のみサポートされています。Windows 7/8 を利用している場合は、OS を Windows 10 以上にアップグレードすることをおすすめします。旧OSでのインストールは過去バージョンを自己責任で導入してください。 詳細はこちら: [Windows7/8に関する注意点](windows-r-japanese-path-issues.md)。
 
 PowerShell の開き方やコマンドの貼り付け方から丁寧に説明します。
 


### PR DESCRIPTION
## Summary
- Link to Japanese path issues note from each Windows installation guide

## Testing
- `markdownlint windows-rig.md windows-rstudio.md windows-winget.md` *(fails: command not found)*
- `npm install -g markdownlint-cli` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a090bc5a308326bf791b7cbd750638