### PR TITLE
Clarify dual licenses for docs and code

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,51 +1,8 @@
-Creative Commons Attribution 4.0 International Public License
+# Dual License
 
-Copyright (c) 2025 mitti1210
+This project is distributed under a dual-license model:
 
-You are free to:
+- Documentation (text, images, guides) is licensed under the Creative Commons Attribution 4.0 International Public License. See [LICENSE-DOCS](LICENSE-DOCS) for the full text.
+- Source code (such as R and shell scripts) is licensed under the MIT License. See [LICENSE-CODE](LICENSE-CODE) for the full text.
 
-- Share — copy and redistribute the material in any medium or format
-- Adapt — remix, transform, and build upon the material
-  for any purpose, even commercially.
-
-The licensor cannot revoke these freedoms as long as you follow the license terms.
-
-Under the following terms:
-
-- Attribution — You must give appropriate credit, provide a link to the license,
-  and indicate if changes were made. You may do so in any reasonable manner,
-  but not in any way that suggests the licensor endorses you or your use.
-
-Notices:  
-You do not have to comply with the license for elements of the material in the
-public domain or where your use is permitted by an applicable exception or limitation.
-
-Full license text: https://creativecommons.org/licenses/by/4.0/
-
-
-Creative Commons Attribution 4.0 International Public License
-
-Copyright (c) 2025 mitti1210
-
-You are free to:
-
-- Share — copy and redistribute the material in any medium or format
-- Adapt — remix, transform, and build upon the material
-  for any purpose, even commercially.
-
-The licensor cannot revoke these freedoms as long as you follow the license terms.
-
-Under the following terms:
-
-- Attribution — You must give appropriate credit, provide a link to the license,
-  and indicate if changes were made. You may do so in any reasonable manner,
-  but not in any way that suggests the licensor endorses you or your use.
-
-Notices:  
-You do not have to comply with the license for elements of the material in the
-public domain or where your use is permitted by an applicable exception or limitation.
-
-Full license text: https://creativecommons.org/licenses/by/4.0/
-
-
-
+By contributing to or using this repository, you agree to comply with the terms of the respective licenses.

--- a/LICENSE-CODE
+++ b/LICENSE-CODE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 mitti1210
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-DOCS
+++ b/LICENSE-DOCS
@@ -1,0 +1,22 @@
+Creative Commons Attribution 4.0 International Public License
+
+Copyright (c) 2025 mitti1210
+
+You are free to:
+
+- Share — copy and redistribute the material in any medium or format
+- Adapt — remix, transform, and build upon the material for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+
+Under the following terms:
+
+- Attribution — You must give appropriate credit, provide a link to the license,
+  and indicate if changes were made. You may do so in any reasonable manner,
+  but not in any way that suggests the licensor endorses you or your use.
+
+Notices:
+You do not have to comply with the license for elements of the material in the
+public domain or where your use is permitted by an applicable exception or limitation.
+
+Full license text: https://creativecommons.org/licenses/by/4.0/

--- a/README.md
+++ b/README.md
@@ -42,19 +42,19 @@
 
 ## ライセンスと免責事項
 
-- **文章（解説・ガイド）**  
-  このリポジトリの文章・図表などのドキュメントは  
-  [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)  
+- **文章（解説・ガイド）**
+  このリポジトリの文章・図表などのドキュメントは
+  [Creative Commons Attribution 4.0 International (CC BY 4.0)](./LICENSE-DOCS)
   のもとで公開されています。
 
-- **コード（R / Bash スクリプト）**  
-  このリポジトリ内のコードは [MIT License](./LICENSE-CODE) で公開されています。  
+- **コード（R / Bash スクリプト）**
+  このリポジトリ内のコードは [MIT License](./LICENSE-CODE) で公開されています。
 
 ---
 
 ## 免責事項
 
-- このリポジトリは MIT ライセンスで提供されています。詳しくは [LICENSE](LICENSE) をご覧ください。
+- このリポジトリは文章とコードで異なるライセンスが適用されています。詳しくは [LICENSE](LICENSE) をご覧ください。
 - 環境は一人ひとり異なるため、手順通りに進めてもトラブルが発生することがあります。
 - ここで紹介するソフトウェアはすべてフリーソフトです。利用は自己責任で行ってください。
 - トラブルが起きた場合は生成 AI や検索エンジンを活用すると解決できることが多いです。


### PR DESCRIPTION
## Summary
- Split licensing into dedicated files for documentation (CC BY 4.0) and code (MIT)
- Add dual-license notice at repository root
- Update README to clearly state which materials fall under each license

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d561f42c8326ab52526bc1c7a0b4