### PR TITLE
docs: add installation verification steps

### DIFF
--- a/mac-homebrew.md
+++ b/mac-homebrew.md
@@ -135,3 +135,23 @@ brew install --cask rstudio
 ## 7. RStudio の初期設定とパッケージのインストール
 
 RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。
+
+## 8. 上手くインストールできるか確認する
+
+1. RStudio のコンソールで次を実行します。
+
+   ```r
+   install.packages("pacman")
+   library(pacman)
+   p_loaded()
+   ```
+
+   `p_loaded()` に `pacman` が表示されれば R とライブラリの設定は正常です。表示されない（`character(0)` が出る、`library(pacman)` で「there is no package called 'pacman'」と表示される）場合はインストールに失敗しています。
+
+### トラブルが起きたときは？
+
+- `brew install r` で R を入れていると不具合が起きることがあります。`brew uninstall r` で削除し、rig か RStudio のサイトからインストールし直してください。
+
+---
+
+環境は一人ひとり異なるため、手順どおりに進めてもトラブルが発生することがあります。エラーが出たときはウェブ検索や生成 AI を活用すると解決できることが多いです。

--- a/mac-rig.md
+++ b/mac-rig.md
@@ -116,3 +116,23 @@ uname -m
 ## 6. RStudio の初期設定とパッケージのインストール
 
 RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。
+
+## 7. 上手くインストールできるか確認する
+
+1. RStudio のコンソールで次を実行します。
+
+   ```r
+   install.packages("pacman")
+   library(pacman)
+   p_loaded()
+   ```
+
+   `p_loaded()` に `pacman` が表示されれば R とライブラリの設定は正常です。表示されない（`character(0)` が出る、`library(pacman)` で「there is no package called 'pacman'」と表示される）場合はインストールに失敗しています。
+
+### トラブルが起きたときは？
+
+- `brew install r` で入れた R が残っていると不具合が起きることがあります。`brew uninstall r` で削除し、rig か RStudio のサイトからインストールし直してください。
+
+---
+
+環境は一人ひとり異なるため、手順どおりに進めてもトラブルが発生することがあります。エラーが出たときはウェブ検索や生成 AI を活用すると解決できることが多いです。

--- a/mac-rstudio.md
+++ b/mac-rstudio.md
@@ -85,3 +85,23 @@ RStudioをはじめて起動する場合は
 と聞かれたら「開く」を選択してください。
 
 RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。
+
+## 5. 上手くインストールできるか確認する
+
+1. RStudio のコンソールで次を実行します。
+
+   ```r
+   install.packages("pacman")
+   library(pacman)
+   p_loaded()
+   ```
+
+   `p_loaded()` に `pacman` が表示されれば R とライブラリの設定は正常です。表示されない（`character(0)` が出る、`library(pacman)` で「there is no package called 'pacman'」と表示される）場合はインストールに失敗しています。
+
+### トラブルが起きたときは？
+
+- `brew install r` で入れた R が残っていると不具合が起きることがあります。`brew uninstall r` で削除し、rig か RStudio のサイトからインストールし直してください。
+
+---
+
+環境は一人ひとり異なるため、手順どおりに進めてもトラブルが発生することがあります。エラーが出たときはウェブ検索や生成 AI を活用すると解決できることが多いです。

--- a/windows-rig.md
+++ b/windows-rig.md
@@ -136,3 +136,23 @@ winget install -e Posit.RStudio
 ## 9. RStudio の初期設定とパッケージのインストール
 
 RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。
+
+## 10. 上手くインストールできるか確認する
+
+1. RStudio のコンソールで次を実行します。
+
+   ```r
+   install.packages("pacman")
+   library(pacman)
+   p_loaded()
+   ```
+
+   `p_loaded()` に `pacman` が表示されれば R とライブラリの設定は正常です。表示されない（`character(0)` が出る、`library(pacman)` で「there is no package called 'pacman'」と表示される）場合はインストールに失敗しています。
+
+### トラブルが起きたときは？
+
+- `install.packages()` が `C:\Users\<ユーザー名>\OneDrive\??????\R\win-library\...` のようなパスで止まる場合は、`R_LIBS_USER` 環境変数が正しく設定されているか確認してください。
+
+---
+
+環境は一人ひとり異なるため、手順どおりに進めてもトラブルが発生することがあります。エラーが出たときはウェブ検索や生成 AI を活用すると解決できることが多いです。

--- a/windows-rstudio.md
+++ b/windows-rstudio.md
@@ -135,3 +135,23 @@ mkdir C:\Users\$Env:USERNAME\Documents\R\libs
 ## 5. RStudio の初期設定とパッケージのインストール
 
 RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。
+
+## 6. 上手くインストールできるか確認する
+
+1. RStudio のコンソールで次を実行します。
+
+   ```r
+   install.packages("pacman")
+   library(pacman)
+   p_loaded()
+   ```
+
+   `p_loaded()` に `pacman` が表示されれば R とライブラリの設定は正常です。表示されない（`character(0)` が出る、`library(pacman)` で「there is no package called 'pacman'」と表示される）場合はインストールに失敗しています。
+
+### トラブルが起きたときは？
+
+- `install.packages()` が `C:\Users\<ユーザー名>\OneDrive\??????\R\win-library\...` のようなパスで止まる場合は、`R_LIBS_USER` 環境変数が正しく設定されているか確認してください。
+
+---
+
+環境は一人ひとり異なるため、手順どおりに進めてもトラブルが発生することがあります。エラーが出たときはウェブ検索や生成 AI を活用すると解決できることが多いです。

--- a/windows-winget.md
+++ b/windows-winget.md
@@ -79,3 +79,23 @@ winget install -e Posit.RStudio
 ## 5. RStudio の初期設定とパッケージのインストール
 
 RStudio の初期設定や必要なパッケージの導入については [RStudioインストール後の準備について](rstudio-post-install.md) を参照してください。
+
+## 6. 上手くインストールできるか確認する
+
+1. RStudio のコンソールで次を実行します。
+
+   ```r
+   install.packages("pacman")
+   library(pacman)
+   p_loaded()
+   ```
+
+   `p_loaded()` に `pacman` が表示されれば R とライブラリの設定は正常です。表示されない（`character(0)` が出る、`library(pacman)` で「there is no package called 'pacman'」と表示される）場合はインストールに失敗しています。
+
+### トラブルが起きたときは？
+
+- `install.packages()` が `C:\Users\<ユーザー名>\OneDrive\??????\R\win-library\...` のようなパスで止まる場合は、`R_LIBS_USER` 環境変数を設定してください。
+
+---
+
+環境は一人ひとり異なるため、手順どおりに進めてもトラブルが発生することがあります。エラーが出たときはウェブ検索や生成 AI を活用すると解決できることが多いです。


### PR DESCRIPTION
## Summary
- guide users to verify R installs by installing and loading pacman
- show example failure outputs (p_loaded result and OneDrive path)
- note troubleshooting tips for Windows env vars and Homebrew-installed R on macOS
- encourage consulting the web or generative AI when errors occur

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a166b459dc8326b772007bb4b847f9